### PR TITLE
Add PolicyTemplates

### DIFF
--- a/examples/blog_complex/roles.go
+++ b/examples/blog_complex/roles.go
@@ -34,9 +34,9 @@ func NewMemberRole(userID string) rbac.Role {
 		Permissions: []rbac.Permission{
 			rbac.NewGlobPermission("CreateArticle", "*"),
 			rbac.NewGlobPermission("ReadArticle", "*"),
+			rbac.NewGlobPermission("RateArticle", "*"),
 			rbac.NewPermission(rbac.GlobMatch("EditArticle"), ifArticleAuthor(userID)),
 			rbac.NewPermission(rbac.GlobMatch("DeleteArticle"), ifArticleAuthor(userID)),
-			rbac.NewGlobPermission("RateArticle", "*"),
 		},
 	}
 }

--- a/examples/iam/iam.go
+++ b/examples/iam/iam.go
@@ -19,7 +19,7 @@ func NewAdminRole() rbac.Role {
 // NewReadOnlyRole returns a rbac.Role that can do any "read" action on any target.
 func NewReadOnlyRole() rbac.Role {
 	return rbac.Role{
-		RoleID: "Admin",
+		RoleID: "ReadOnly",
 		Permissions: []rbac.Permission{
 			rbac.NewGlobPermission("read:*", "*"),
 		},

--- a/policy.go
+++ b/policy.go
@@ -6,11 +6,21 @@ import (
 	"strings"
 )
 
-// A PolicyTemplate holds information about a Role in a templated format
-type PolicyTemplate struct {
-	RoleID              string                                            `json:"role_id"`
-	PermissionTemplates []PermissionTemplate                              `json:"permissions"`
-	constructors        map[string]func(action, target string) Permission `json:"-"`
+// A PermissionConstructor is a function that creates a new Permission
+// from the specified action and target strings.
+type PermissionConstructor func(action, target string) Permission
+
+// DefaultPermissionConstructors returns a mapping of constructor names to PermissionConstructor functions
+// for each of the builtin PermissionConstructors:
+//   "glob":  NewGlobPermission
+//   "regex":  NewRegexPermission
+//   "string": NewStringPermission
+func DefaultPermissionConstructors() map[string]PermissionConstructor {
+	return map[string]PermissionConstructor{
+		"glob":   NewGlobPermission,
+		"regex":  NewRegexPermission,
+		"string": NewStringPermission,
+	}
 }
 
 // A PermissionTemplate holds information about a permission in templated format.
@@ -20,40 +30,50 @@ type PermissionTemplate struct {
 	Target      string `json:"target"`
 }
 
-// NewPolicyTemplate generates a new PolicyTemplate with the specified roleID.
+// A PolicyTemplate holds information about a Role in a templated format.
+// This format can be encoded to and from JSON.
+type PolicyTemplate struct {
+	RoleID              string                           `json:"role_id"`
+	PermissionTemplates []PermissionTemplate             `json:"permissions"`
+	constructors        map[string]PermissionConstructor `json:"-"`
+}
+
+// NewPolicyTemplate generates a new PolicyTemplate with the specified roleID and default constructors.
 func NewPolicyTemplate(roleID string) *PolicyTemplate {
 	return &PolicyTemplate{
 		RoleID:              roleID,
 		PermissionTemplates: []PermissionTemplate{},
-		constructors:        DefaultConstructors(),
+		constructors:        DefaultPermissionConstructors(),
 	}
 }
 
-func (p *PolicyTemplate) AddPermission(constructor, action, target string) *PolicyTemplate {
+// AddPermission adds a new PermissionTemplate to p.PermissionTemplates.
+func (p *PolicyTemplate) AddPermission(constructor, action, target string) {
 	p.PermissionTemplates = append(p.PermissionTemplates, PermissionTemplate{constructor, action, target})
-	return p
 }
 
-func (p *PolicyTemplate) SetConstructor(name string, constructor func(action, target string) Permission) *PolicyTemplate {
+// SetConstructor updates the mapping of a constructor name to a PermissionConstructor.
+// If a mapping for the specified same name already exists, it will be overwritten.
+func (p *PolicyTemplate) SetConstructor(name string, constructor PermissionConstructor) {
 	p.constructors[name] = constructor
-	return p
 }
 
-func DefaultConstructors() map[string]func(action, target string) Permission {
-	return map[string]func(action, target string) Permission{
-		"glob":   NewGlobPermission,
-		"regex":  NewRegexPermission,
-		"string": NewStringPermission,
+// DeleteConstructor will remove the constructor mapping at the specified name if it exists.
+func (p *PolicyTemplate) DeleteConstructor(name string) {
+	if _, ok := p.constructors[name]; ok {
+		delete(p.constructors, name)
 	}
 }
 
-func (p *PolicyTemplate) Role(oldnew ...string) (*Role, error) {
+// Role converts the PolicyTemplate to a Role.
+// Replacer can be used to replace variables within the Action and Target fields in the PermissionTemplates.
+// An error will be returned if a PermissionTemplate.Constructor does not have a corresponding PermissionConstructor.
+func (p *PolicyTemplate) Role(replacer *strings.Replacer) (*Role, error) {
 	role := &Role{
 		RoleID:      p.RoleID,
 		Permissions: make(Permissions, len(p.PermissionTemplates)),
 	}
 
-	replacer := strings.NewReplacer(oldnew...)
 	for i, permissionTemplate := range p.PermissionTemplates {
 		constructor, ok := p.constructors[permissionTemplate.Constructor]
 		if !ok {
@@ -68,6 +88,8 @@ func (p *PolicyTemplate) Role(oldnew ...string) (*Role, error) {
 	return role, nil
 }
 
+// UnmarshalJSON allows a *PolicyTemplate to implement the json.Unmarshaler interface.
+// We do this to set the default constructors on p after the unmarshalling.
 func (p *PolicyTemplate) UnmarshalJSON(data []byte) error {
 	type Alias PolicyTemplate
 	aux := &struct {
@@ -80,6 +102,6 @@ func (p *PolicyTemplate) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	p.constructors = DefaultConstructors()
+	p.constructors = DefaultPermissionConstructors()
 	return nil
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -3,15 +3,18 @@ package rbac
 import (
 	"encoding/json"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPolicyTemplate(t *testing.T) {
-	p := NewPolicyTemplate("Admin").
-		AddPermission("glob", "*", "grid:*:$userID:*").
-		AddPermission("glob", "read:*", "*")
+	t.Skip("TODO: read/write to/from a buffer")
+
+	p := NewPolicyTemplate("Admin")
+	p.AddPermission("glob", "*", "grid:*:$userID:*")
+	p.AddPermission("glob", "read:*", "*")
 
 	bytes, err := json.MarshalIndent(p, "", "    ")
 	if err != nil {
@@ -32,7 +35,7 @@ func TestPolicyTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	role, err := policy.Role("$userID", "u123")
+	role, err := policy.Role(strings.NewReplacer("$userID", "u123"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows a role to be encoded/decoded as a `PolicyTemplate`. 
A `PolicyTemplate` can be used for persistent storage. 